### PR TITLE
Fix len called on None preventing usage of spectrums with no peaks

### DIFF
--- a/psims/mzml/writer.py
+++ b/psims/mzml/writer.py
@@ -479,7 +479,7 @@ class PlainMzMLWriter(ComponentDispatcher, XMLDocumentWriter):
         params.append(peak_mode)
 
         array_list = []
-        default_array_length = len(mz_array)
+        default_array_length = len(mz_array) if mz_array is not None else 0
         if mz_array is not None:
             mz_array_tag = self._prepare_array(
                 mz_array, encoding=encoding[MZ_ARRAY], compression=compression, array_type=MZ_ARRAY)


### PR DESCRIPTION
In http://www.peptideatlas.org/tmp/mzML1.1.0.html#spectrum it states that

> If a scan yields no peaks, it should still be reported

I'm guessing by the `None` checking that support for this was intended. It's just the unchecked calling of `len(mz_array)` that needs fixing. :)