### PR TITLE
corrected spectrum list count in README.md minimaml mzML example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ with MzMLWriter(open("out.mzML", 'wb')) as out:
     out.controlled_vocabularies()
     # Open the run and spectrum list sections
     with out.run(id="my_analysis"):
-        with out.spectrum_list(count=len(scans)):
+        spectrum_count = len(scans) + sum([len(products) for _, products in scans])
+        with out.spectrum_list(count=spectrum_count):
             for scan, products in scans:
                 # Write Precursor scan
                 out.write_spectrum(


### PR DESCRIPTION
The example provided https://mobiusklein.github.io/psims/docs/build/html/examples.html and the minimal example in the README.md differ in one key way. The `spectrum_list`'s `count` param. In the README.md only MS1 spectra are included. In the longer form example all spectra are included.