### PR TITLE
Add install instructions for pip and conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,23 @@
 # psims
 Prototype work for a unified API for writing Proteomics Standards Initiative standardized formats
 for mass spectrometry:
-    1. mzML
-    2. mzIdentML
-    3. mzMLb
+
+1. mzML
+2. mzIdentML
+3. mzMLb
 
 See the [Documenation](https://mobiusklein.github.io/psims) for more information
+
+## Installation
+With pip:
+```sh
+pip install psims
+```
+
+With conda:
+```sh
+conda install -c bioconda -c conda-forge -c defaults psims
+```
 
 ## mzML Minimal Example
 


### PR DESCRIPTION
This PR adds installation instructions for pip and conda to the `README.md` file and fixes the list formatting in the header. Feel free to close the PR if you prefer to keep the README.md minimal.

Bioconda recipe for `psims` was added in https://github.com/bioconda/bioconda-recipes/pull/32721.
`psims` at anaconda.org: https://anaconda.org/bioconda/psims